### PR TITLE
add MIT licencse

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2022 Monzo Bank Limited
+Copyright (c) 2024 Monzo Bank Limited
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
uses the same license as Typhon and egress-operator, other Monzo open-source projects
