### PR TITLE
fix bug where name in buildEif was not carried over to EIF filename

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -186,7 +186,7 @@
               inherit pkgs;
 
               buildEif =
-                { name ? "image"
+                { name ? "image-linux-${arch}-${version}-eif"
                 , version ? "0.1-dev"
                 , kernel # path (derivation) to compiled kernel binary
                 , kernelConfig       # path (derivation) to kernel config file
@@ -213,7 +213,7 @@
                   rootfs = if copyToRootWithClosure then nixStoreFrom copyToRoot else copyToRoot;
                 in
                 lib.mkEif {
-                  inherit kernel kernelConfig cmdline arch;
+                  inherit kernel kernelConfig cmdline arch name version;
 
                   ramdisks = [
                     (lib.mkSysRamdisk { inherit init nsmKo; })


### PR DESCRIPTION
buildEif is a function that returns a built EIF and takes `name` and `version` parameters.

The issue was that these were not passed to the actual EIF CLI later on, so they were never included in the metadata of the EIF. This resulted in EIFs with different names producing very similarly named files.

This change only affects EIF metadata, so it should not involve PCR changes.
