### PR TITLE
Add example for using your own kernel in enclaves

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The tradeoffs between using this repo and AWS' `nitro-cli` are:
 | Feature | `nitro-cli build-enclave` | monzo/aws-nitro-util |
 |---------|-----------|----------------------|
 | EIF userspace input | Docker container | plain files, including nix packages and unpacked OCI images
-| EIF bootstrap input | pre-compiled kernel binary provided by AWS | use pre-compiled kernel by AWS or any other valid Kernel (for example see [this PR](https://github.com/aws/aws-nitro-enclaves-sdk-bootstrap/pull/22))
+| EIF bootstrap input | pre-compiled kernel binary provided by AWS | use pre-compiled kernel by AWS or bring your own kernel (see [example](./examples/README.md))
 | dependencies | Docker, linuxkit fork, [aws/aws-nitro-enclaves-image-format](https://github.com/aws/aws-nitro-enclaves-image-format/) | Nix, [aws/aws-nitro-enclaves-image-format](https://github.com/aws/aws-nitro-enclaves-image-format/)
 | Source-reproducible | no, uses pre-compiled blobs provided by AWS | yes, can be built entirely from source
 | Bit-by-bit reproducible EIFs | no, EIFs are timestamped | yes, building the same EIF will result in the same SHA256

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,4 +4,7 @@ Examples are structured as a single flake containing packages of potential EIFs.
 
 To see the overall plumbing to use the aws-nitro-util flake, see [flake.nix](./flake.nix).
 
-To see examples for specific EIFs, see the individual package definitions (like [withShellScript.nix](./withShellScript.nix)).
+To see examples for specific EIFs, see the individual package definitions:
+
+- Booting an enclave with a shell script only: [`withShellScript.nix`](./withShellScript.nix)
+- Booting an enclave with your own, compiled-from-source kernel: [`bringYourOwnKernel.nix`](./bringYourOwnKernel.nix)

--- a/examples/bringYourOwnKernel.nix
+++ b/examples/bringYourOwnKernel.nix
@@ -36,7 +36,7 @@ nitro.buildEif {
   name = "eif-hello-world";
 
   # do not include a nsm.ko kernel module, as it is
-  # alerady present in Kernel 6.8+
+  # already present in Kernel 6.8+
   nsmKo = null;
 
   copyToRoot = buildEnv {

--- a/examples/bringYourOwnKernel.nix
+++ b/examples/bringYourOwnKernel.nix
@@ -1,0 +1,50 @@
+{ lib
+, linux_6_8
+, buildEnv
+, writeShellScriptBin
+, busybox
+, nitro # this should be nitro-util.lib.${system}
+, stdenv
+}:
+let
+  myScript = writeShellScriptBin "hello" ''
+    export PATH="$PATH:${busybox}/bin"
+    while true;
+    do
+      echo "hello there!";
+      sleep 3;
+    done
+  '';
+  arch = stdenv.hostPlatform.uname.processor;
+  # use kernel 6.8 with virtio and vsocks
+  kernel = linux_6_8.override {
+    structuredExtraConfig = with lib.kernel; {
+      VIRTIO_MMIO = yes;
+      VIRTIO_MENU = yes;
+      VIRTIO_MMIO_CMDLINE_DEVICES = yes;
+      NET = yes;
+      VSOCKETS = yes;
+      VIRTIO_VSOCKETS = yes;
+    };
+    ignoreConfigErrors = true;
+  };
+in
+nitro.buildEif {
+  kernel = kernel + (if arch == "aarch64" then "/Image" else "/bzImage");
+  kernelConfig = kernel.configfile;
+
+  name = "eif-hello-world";
+
+  # do not include a nsm.ko kernel module, as it is
+  # alerady present in Kernel 6.8+
+  nsmKo = null;
+
+  copyToRoot = buildEnv {
+    name = "image-root";
+    paths = [ myScript ];
+    pathsToLink = [ "/bin" ];
+  };
+
+  entrypoint = "/bin/hello";
+  env = "";
+}

--- a/examples/flake.lock
+++ b/examples/flake.lock
@@ -59,16 +59,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1713013257,
-        "narHash": "sha256-ZEfGB3YCBVggvk0BQIqVY7J8XF/9jxQ68fCca6nib+8=",
+        "lastModified": 1717602782,
+        "narHash": "sha256-pL9jeus5QpX5R+9rsp3hhZ+uplVHscNJh8n8VpqscM0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "90055d5e616bd943795d38808c94dbf0dd35abe8",
+        "rev": "e8057b67ebf307f01bdcc8fba94d94f75039d1f6",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.11",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/examples/flake.nix
+++ b/examples/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     nitro-util.url = "github:monzo/aws-nitro-util";
     nitro-util.inputs.nixpkgs.follows = "nixpkgs";
@@ -21,6 +21,10 @@
 
 
         yourOwnInitEif = pkgs.callPackage ./withYourInit.nix {
+          inherit nitro;
+        };
+
+        yourOwnKernelEif = pkgs.callPackage ./bringYourOwnKernel.nix {
           inherit nitro;
         };
 


### PR DESCRIPTION
Also updates examples' nixpkgs to unstable.

Refer to [the official Nix docs](https://nixos.wiki/wiki/Linux_kernel) for more details on how to compile the Linux kernel.
