### PR TITLE
fix argv0 not being passed to ForkExec

### DIFF
--- a/examples/flake.lock
+++ b/examples/flake.lock
@@ -44,17 +44,14 @@
         ]
       },
       "locked": {
-        "lastModified": 1714745550,
-        "narHash": "sha256-ralB0D0tG9ERgjRlit7t2pRI5lclnqOcqclzqj41EN4=",
-        "owner": "monzo",
-        "repo": "aws-nitro-util",
-        "rev": "00f74d348d8f5fbf3f2fc4edf018e20d6b9a7144",
-        "type": "github"
+        "lastModified": 0,
+        "narHash": "sha256-9ui9jwz/cjxkvl38/dacy0tM6WZohx7kh3rIXtbG7eA=",
+        "path": "../",
+        "type": "path"
       },
       "original": {
-        "owner": "monzo",
-        "repo": "aws-nitro-util",
-        "type": "github"
+        "path": "../",
+        "type": "path"
       }
     },
     "nixpkgs": {

--- a/examples/flake.nix
+++ b/examples/flake.nix
@@ -2,7 +2,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-    nitro-util.url = "github:monzo/aws-nitro-util";
+    nitro-util.url = "path:../";
     nitro-util.inputs.nixpkgs.follows = "nixpkgs";
 
     flake-utils.url = "github:numtide/flake-utils";

--- a/examples/withShellScript.nix
+++ b/examples/withShellScript.nix
@@ -12,7 +12,7 @@ let
 
     while true;
     do
-      echo "hello there!";
+      echo "hello there $1 !";
       sleep 3;
     done
   '';
@@ -33,6 +33,10 @@ nitro.buildEif {
     pathsToLink = [ "/bin" ];
   };
 
-  entrypoint = "/bin/hello";
+  entrypoint = ''
+    /bin/hello
+    there
+  '';
+
   env = "";
 }

--- a/init/init.go
+++ b/init/init.go
@@ -368,7 +368,7 @@ func main() {
 		die("failed to init cgroups", err)
 	}
 
-	pid, err := launch(cmd[0], cmd[1:], env)
+	pid, err := launch(cmd[0], cmd, env)
 
 	if err != nil {
 		die("failed to launch", err)


### PR DESCRIPTION
Fixes argv0 not being passed to ForkExec's 2nd parameter. This also
- changes examples to include the aws-nitro-util in `../` rather than fetching it from github
- adds arg to example so we show using arguments in `cmd`

closes https://github.com/monzo/aws-nitro-util/issues/22
